### PR TITLE
Toolchain changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@ Kernel is only targetting x86 (i386+) computers and as of now it supports Multib
 ## Nice! How do I compile?
 Compiling and correctly linking the kernel requires setting up a cross-compiler and toolchain (GCC and Binutils) for your system. Kernel will **not** compile correctly under your platform specific toolchain **even** if you are running x86. You can try passing flags to GCC to get it to compile in freestanding mode without linking to your OS's libraries but you are on your own. Consider yourself warned!
 
-In order to build a cross-compiler, run the script provided in the utils to set up a toolchain automatically, by typing *make toolchain*.
-
-After you have set up your cross-toolchain ~~edit the Makefile so that it points to your cross-binaries,~~ type *make* and voila!
+In order to build a cross-compiler, run the script provided in the utils to set up a toolchain automatically and then add the new toolchain to your PATH, by typing `make toolchain && source ./utils/use-toolchain.sh`, and then all you have to do is type `make` and voila!
 
 ## I have my binaries, now what?
-You can test it under QEMU, or you can set up a partition with GRUB (or even LILO, SystemCommander and so on) to boot it. Type *make run*.
+You can test it under QEMU, or you can set up a partition with GRUB (or even LILO, SystemCommander and so on) to boot it. Type `make run`.
 
 ## It crashed! :(
 This will probably happen more often than not. Send me a screenshot of the panic screen and I might be able to fix it!

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -35,9 +35,9 @@ CFLAGS=-nostdlib -nostdinc -fno-builtin -fno-stack-protector -std=c11 -I ./inc -
 LDFLAGS=-T ./conf/link-kernel.ld -nostdlib -Map=bin/kernel.map
 ASFLAGS= -f elf
 
-LD=./toolchain/bin/i686-elf-ld
+LD=i686-elf-ld
 AS=nasm
-CC=./toolchain/bin/i686-elf-gcc
+CC=i686-elf-gcc
 
 all: 	$(SRCS) link ramdisk
 	@printf "\n[+] Done!\n\n"

--- a/kernel/utils/rdgen.c
+++ b/kernel/utils/rdgen.c
@@ -2,57 +2,52 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct initrd_header
-{
-	unsigned char magic;
-	char name[64];
-	unsigned int offset;
-	unsigned int length;
+struct initrd_header {
+  unsigned char magic;
+  char name[64];
+  unsigned int offset;
+  unsigned int length;
 };
 
-int main(char argc, char **argv)
-{
-	
-	int nheaders = (argc-2);
-	struct initrd_header headers[64];
-	printf("Ramdisk Header Size: %d\n", sizeof(struct initrd_header));
-	unsigned int off = sizeof(struct initrd_header) * 64 + sizeof(int);
+int main(int argc, char **argv) {
 
-	for(int i = 0; i < nheaders; i++)
-	{
-		printf("Injecting file %s at 0x%x\n", argv[i+2], off);
-		strcpy(headers[i].name, argv[i+2]);
-		headers[i].offset = off;
-		FILE *stream = fopen(argv[i+2], "r");
-		if(stream == 0)
-		{
-			printf("Error: file not found: %s\n", argv[i+2]);
-			return 1;
-		}
-		fseek(stream, 0, SEEK_END);
-		headers[i].length = ftell(stream);
-		off += headers[i].length;
-		fclose(stream);
-		headers[i].magic = 0xBF;
-	}
-	
-	FILE *wstream = fopen(argv[1], "w");
-	unsigned char *data = (unsigned char *)malloc(off);
-	fwrite(&nheaders, sizeof(int), 1, wstream);
-	fwrite(headers, sizeof(struct initrd_header), 64, wstream);
-	
-	for(int i = 0; i < nheaders; i++)
-	{
-		FILE *stream = fopen(argv[i+2], "r");
-		unsigned char *buf = (unsigned char *)malloc(headers[i].length);
-		fread(buf, 1, headers[i].length, stream);
-		fwrite(buf, 1, headers[i].length, wstream);
-		fclose(stream);
-		free(buf);
-	}
-	
-	fclose(wstream);
-	free(data);
+  int nheaders = (argc - 2);
+  struct initrd_header headers[64];
+  printf("Ramdisk Header Size: %lu\n", sizeof(struct initrd_header));
+  unsigned int off = sizeof(struct initrd_header) * 64 + sizeof(int);
 
-	return 0;	
+  for (int i = 0; i < nheaders; i++) {
+    printf("Injecting file %s at 0x%x\n", argv[i + 2], off);
+    strcpy(headers[i].name, argv[i + 2]);
+    headers[i].offset = off;
+    FILE *stream = fopen(argv[i + 2], "r");
+    if (stream == 0) {
+      printf("Error: file not found: %s\n", argv[i + 2]);
+      return 1;
+    }
+    fseek(stream, 0, SEEK_END);
+    headers[i].length = ftell(stream);
+    off += headers[i].length;
+    fclose(stream);
+    headers[i].magic = 0xBF;
+  }
+
+  FILE *wstream = fopen(argv[1], "w");
+  unsigned char *data = (unsigned char *)malloc(off);
+  fwrite(&nheaders, sizeof(int), 1, wstream);
+  fwrite(headers, sizeof(struct initrd_header), 64, wstream);
+
+  for (int i = 0; i < nheaders; i++) {
+    FILE *stream = fopen(argv[i + 2], "r");
+    unsigned char *buf = (unsigned char *)malloc(headers[i].length);
+    fread(buf, 1, headers[i].length, stream);
+    fwrite(buf, 1, headers[i].length, wstream);
+    fclose(stream);
+    free(buf);
+  }
+
+  fclose(wstream);
+  free(data);
+
+  return 0;
 }

--- a/kernel/utils/use-toolchain.sh
+++ b/kernel/utils/use-toolchain.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+PREFIX="$DIR/../toolchain"
+
+export PATH="$PREFIX/bin:$PATH"
+echo "$PATH"


### PR DESCRIPTION
This patch adds a script that you can source and it'll add the toolchain directory to your PATH, making things easier for those who already have cross compilers set up elsewhere, and removes relative paths from the Makefile. I also made a few changes to rdgen.c to allow me to compile it, but it looks like my editor's auto clang-format got to it :P

Let me know if this is unnecessary or if anything needs changing!